### PR TITLE
complying with specifications.freedesktop.org about a default value for XDG_CONFIG_HOME

### DIFF
--- a/install
+++ b/install
@@ -26,6 +26,12 @@ exit 1
 
 
 init_config_file () {
+    if [ -z "$XDG_CONFIG_HOME" ]; then
+        mkdir --parents "$HOME/.config/ixwindow"
+        cp "examples/ixwindow.toml" "$HOME/.config/ixwindow/ixwindow.toml"
+        return
+    fi
+
     mkdir --parents "$XDG_CONFIG_HOME/ixwindow"
     cp "examples/ixwindow.toml" "$XDG_CONFIG_HOME/ixwindow/ixwindow.toml"
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,18 +112,36 @@ pub fn load_bspwm(config_option: Option<&str>) -> BspwmConfig {
 }
 
 fn locate_config_file() -> Option<String> {
-    if let Ok(default_dir) = env::var("XDG_CONFIG_HOME") {
-        let default_config = format!("{default_dir}/ixwindow/ixwindow.toml");
-
-        if Path::new(&default_config).exists() {
-            return Some(default_config);
-        }
-    }
-
     if let Ok(specified_config) = env::var("IXWINDOW_CONFIG_PATH") {
         if Path::new(&specified_config).exists() {
             return Some(specified_config);
         }
+    }
+
+    // default_dir is $XDG_CONFIG_HOME if XDG_CONFIG_HOME is set and not empty,
+    // otherwise it is "$HOME/.config"
+    let default_dir = match env::var("XDG_CONFIG_HOME") {
+        Err(_error) => format!(
+            "{}/.config",
+            env::var("HOME").expect(
+                "$HOME is not set, but is needed \
+             because $XDG_CONFIG_HOME is not set"
+            )
+        ),
+        Ok(path) if path.is_empty() => format!(
+            "{}/.config",
+            env::var("HOME").expect(
+                "$HOME is not set, but is needed \
+                 because $XDG_CONFIG_HOME is empty"
+            )
+        ),
+        Ok(path) => path,
+    };
+
+    let default_config = format!("{default_dir}/ixwindow/ixwindow.toml");
+
+    if Path::new(&default_config).exists() {
+        return Some(default_config);
     }
 
     None


### PR DESCRIPTION
according to [freedesktop.org's specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html): "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.".
this pull request would apply that specification.

also, the existing implementation of `src/config.rs` looks for the configuration file in the default directory before a specific (user defined) directory. I don't believe this was intentional. because having a default value for  XDG_CONFIG_HOME would cause the code that looks for the configuration file in the specific directory to be unreachable, this pull request makes it so that the configuration is looked for in the specific directory, before the default one (and not after).