### PR TITLE
Minor enhancements and crash fixes for i3wm

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -302,10 +302,13 @@ where
 
         // Don't add '\n' at the end, so that it will appear in front of icon
         // name, printed after it
-        print!("{}", match state.curr_icon_name.as_ref().unwrap() {
-            IconName::Empty => "",
-            IconName::Name(_) => self.config.gap(),
-        });
+        print!(
+            "{}",
+            match state.curr_icon_name.as_ref().unwrap() {
+                IconName::Empty => "",
+                IconName::Name(_) => self.config.gap(),
+            }
+        );
         io::stdout().flush().unwrap();
 
         match state.curr_icon_name.as_ref().unwrap() {

--- a/src/core.rs
+++ b/src/core.rs
@@ -282,7 +282,7 @@ where
         let state = &self.monitor.state;
 
         if state.curr_icon_name.is_none() {
-            println!("Empty");
+            println!("Desktop");
             return;
         }
 
@@ -306,7 +306,7 @@ where
         io::stdout().flush().unwrap();
 
         match state.curr_icon_name.as_ref().unwrap() {
-            IconName::Empty => println!("Empty"),
+            IconName::Empty => println!("Desktop"),
 
             IconName::Name(icon_name) => match icon_name.as_str() {
                 "Brave-browser" => println!("Brave"),

--- a/src/core.rs
+++ b/src/core.rs
@@ -178,7 +178,7 @@ where
         let config = &self.config;
 
         if !Path::new(config.cache_dir()).is_dir() {
-            fs::create_dir(config.cache_dir())
+            fs::create_dir_all(config.cache_dir())
                 .expect("No cache folder was detected and couldn't create it");
         }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -302,7 +302,10 @@ where
 
         // Don't add '\n' at the end, so that it will appear in front of icon
         // name, printed after it
-        print!("{}", self.config.gap());
+        print!("{}", match state.curr_icon_name.as_ref().unwrap() {
+            IconName::Empty => "",
+            IconName::Name(_) => self.config.gap(),
+        });
         io::stdout().flush().unwrap();
 
         match state.curr_icon_name.as_ref().unwrap() {

--- a/src/i3.rs
+++ b/src/i3.rs
@@ -43,7 +43,9 @@ impl Core<I3Connection, I3Config> {
             Event::WindowEvent(e) => self.handle_window_event(e),
             Event::WorkspaceEvent(e) => self.handle_workspace_event(e),
             // Prevent panic when switching binding mode or hotplugging outputs
-            Event::ModeEvent(_) | Event::OutputEvent(_) => self.handle_general_event(),
+            Event::ModeEvent(_) | Event::OutputEvent(_) => {
+                self.handle_general_event()
+            }
             e => {
                 unreachable!("{:?}", e);
             }
@@ -126,7 +128,10 @@ impl Core<I3Connection, I3Config> {
         let window = self.get_focused_window_id();
         let id = match window {
             Some(x) => x,
-            None => { self.process_empty_desktop(); return }
+            None => {
+                self.process_empty_desktop();
+                return;
+            }
         };
         self.process_focused_window(id);
     }

--- a/src/i3.rs
+++ b/src/i3.rs
@@ -42,8 +42,10 @@ impl Core<I3Connection, I3Config> {
         match event {
             Event::WindowEvent(e) => self.handle_window_event(e),
             Event::WorkspaceEvent(e) => self.handle_workspace_event(e),
-            _ => {
-                unreachable!();
+            // Prevent panic when switching binding mode or hotplugging outputs
+            Event::ModeEvent(_) | Event::OutputEvent(_) => self.handle_general_event(),
+            e => {
+                unreachable!("{:?}", e);
             }
         }
     }
@@ -117,5 +119,15 @@ impl Core<I3Connection, I3Config> {
 
             _ => {}
         }
+    }
+
+    // In a general case, we want to just update the icon name and location
+    fn handle_general_event(&mut self) {
+        let window = self.get_focused_window_id();
+        let id = match window {
+            Some(x) => x,
+            None => { self.process_empty_desktop(); return }
+        };
+        self.process_focused_window(id);
     }
 }


### PR DESCRIPTION
- Handle `XDG_CONFIG_HOME` on systems where `XDG_CONFIG_HOME` is not set. This defaults to `$HOME/.config` [per the XDG Base Directories specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables)
- Automatically create parent directories for cache if the parent directories do not exist
- When not focused on anything, output `Desktop` instead of `Empty`
- When no icon is found or the icon is empty, do not print the gap
- If a config file already exists, running `./install` will no longer overwrite it
- Fix a crash when hot-plugging monitors (`OutputEvent`) or switching binding modes (`ModeEvent`) in i3wm